### PR TITLE
Merge improved tests for ParseRaw and ParseUserMask

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,9 @@ before_install:
 - go get github.com/mattn/goveralls
 - go get golang.org/x/tools/cmd/cover
 script:
-- "$HOME/gopath/bin/goveralls -service=travis-ci"
+- go test -v -covermode=count -coverprofile=profile.cov
+after_script:
+- $HOME/gopath/bin/goveralls -coverprofile=profile.cov -service=travis-ci
 env:
   global:
     secure: EJbeaSjkrITApF99cjVMnaLx2zDntGKLYCGFO7SCD08zSjs9+PiMZbx1wc3/ptj4CE3OeRu09iyFnyQ+m604Wfr5tU3TdPUOtYPpeW2UXHBs19zsZbur/Z2n2bmpRtJCLdIghEi6KCC3+NqzWvCGR7PGXZ0upR01V/BD7vJiUFxjFVthV1qZAY/FtfGWzuaj/+YU41eBqEavAh4KaF3CecFMhgg8z/xR292rLLS0h+oJHGaQnzyq4zDu/CSmSbutmDEhtlNKA59LgfE16WTC6JjgIXcA8h0VDOW3vYkMohzwPUQPPAU4yULYoEjtdmlhTwkxvqQiVNY5JnY3XUGhvF270WyiD9cza/12+zBdHesM3F3PgBwXxTq1pdlyzOeY57IHAcVjbGGX+JXPx+mMQh/lipWb++nnaZFjRBUQ7gWtIi4d083InG77+/+z9da5Ui3K+ocaqjvU2lfMQWQZnZleYtbIoAt0YqF4aG9LdpJoyKbT3wIAkS1qCBODLRnbrRUULUhjEOi46cQbUEpdqyBJozc6nblgRUUzWKkVc0f82pfUE8s6iv6BIc/JUGd5JFpn/KkUK909wX+1y3PgV+6Ode0xU97LyJmbWvswgEMm0H4qf8thW2vf+pvVa1tkCWjagMckrYZSTyfLsa+70C1xnvjrCPp8l3iz9RjEojk=

--- a/parse_test.go
+++ b/parse_test.go
@@ -319,35 +319,35 @@ func TestParseRawInvalid4(t *testing.T) {
 // PARSE RAW BENCHMARKS -------------------------------------------------------
 // ----------------------------------------------------------------------------
 
-func BenchmarkParseRawNumeric(b *testing.B){
+func BenchmarkParseRawNumeric(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		_, err := ParseRaw(":server.test 001 TestUser :Welcome to the "+
+		_, err := ParseRaw(":server.test 001 TestUser :Welcome to the " +
 			"TestNet IRC Network TestUser!test@user.client.test\r\n")
 		if err != nil {
 			b.FailNow()
 		}
 	}
 }
-func BenchmarkParseRawPrivmsg(b *testing.B){
+func BenchmarkParseRawPrivmsg(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		_, err := ParseRaw(":OtherUser!foo@second.client.test PRIVMSG TestUser"+
+		_, err := ParseRaw(":OtherUser!foo@second.client.test PRIVMSG TestUser" +
 			" :This is a message. Boo!\r\n")
 		if err != nil {
 			b.FailNow()
 		}
 	}
 }
-func BenchmarkParseRawCaps(b *testing.B){
+func BenchmarkParseRawCaps(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		_, err := ParseRaw(":server.test 005 TestUser CAP1 CAP2 CAP3 CAP4 "+
-			"CAP5 CAP6 CAP7 CAP8 CAP9 CAP10 CAP11 CAP12 CAP13 are "+
+		_, err := ParseRaw(":server.test 005 TestUser CAP1 CAP2 CAP3 CAP4 " +
+			"CAP5 CAP6 CAP7 CAP8 CAP9 CAP10 CAP11 CAP12 CAP13 are " +
 			"supported by this server\r\n")
 		if err != nil {
 			b.FailNow()
 		}
 	}
 }
-func BenchmarkParseRawPing(b *testing.B){
+func BenchmarkParseRawPing(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		_, err := ParseRaw("PING :BOOP\r\n")
 		if err != nil {
@@ -575,7 +575,7 @@ func TestParseUserMaskInvalid5(t *testing.T) {
 // PARSE USER MASK BENCHMARKS -------------------------------------------------
 // ----------------------------------------------------------------------------
 
-func BenchmarkParseUserMaskUserLong(b *testing.B){
+func BenchmarkParseUserMaskUserLong(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		_, err := ParseUserMask("TestUser!test@user.client.test")
 		if err != nil {
@@ -583,7 +583,7 @@ func BenchmarkParseUserMaskUserLong(b *testing.B){
 		}
 	}
 }
-func BenchmarkParseUserMaskUserShort(b *testing.B){
+func BenchmarkParseUserMaskUserShort(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		_, err := ParseUserMask("TestUser@user.client.test")
 		if err != nil {
@@ -591,7 +591,7 @@ func BenchmarkParseUserMaskUserShort(b *testing.B){
 		}
 	}
 }
-func BenchmarkParseUserMaskServer(b *testing.B){
+func BenchmarkParseUserMaskServer(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		_, err := ParseUserMask("server.test")
 		if err != nil {
@@ -599,7 +599,7 @@ func BenchmarkParseUserMaskServer(b *testing.B){
 		}
 	}
 }
-func BenchmarkParseUserMaskAmbigious(b *testing.B){
+func BenchmarkParseUserMaskAmbigious(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		_, err := ParseUserMask("test")
 		if err != nil {

--- a/parse_test.go
+++ b/parse_test.go
@@ -269,6 +269,27 @@ func testGoodParseUserMask(testMask, expectedType, expectedNick, expectedUser,
 
 	return parsedMask, nil
 }
+func testBadParseUserMask(testMask string, expectedErrorMsg string) (error,
+	error) {
+	var parsedMask IrcUserMask
+	var err error
+	parsedMask, err = ParseUserMask(testMask)
+
+	if !reflect.DeepEqual(parsedMask, IrcUserMask{}) {
+		return err, fmt.Errorf("ParseUserMask returned a non-empty "+
+			"IrcUserMask object, which wasn't expected. The returned object "+
+			"is: %+v", parsedMask)
+	} else if err == nil {
+		return err, fmt.Errorf("ParseUserMask returned an empty error, which "+
+			"wasn't expected.")
+	} else if err.Error() != expectedErrorMsg {
+		return err, fmt.Errorf("ParseUserMask returned an unexpected error "+
+			"of '%s'. We were expecting an error of '%s'.", err.Error(),
+			expectedErrorMsg)
+	}
+
+	return err, nil
+}
 
 func TestParseUserMaskValidUser1(t *testing.T) {
 	parsedMask, err := testGoodParseUserMask("TestUser!test@user.client.test",
@@ -307,114 +328,49 @@ func TestParseUserMaskValidAmbigiousMask1(t *testing.T) {
 	t.Logf("Returned structure is: %+v", parsedMask)
 }
 func TestParseUserMaskInvalid1(t *testing.T) {
-	unparsedmask := "test!x!x@client.test"
-	var parsedmask IrcUserMask
-	var err error
+	pumErr, testErr := testBadParseUserMask("test!x!x@client.test",
+		"User mask has multiple nick/user seperators.")
 
-	parsedmask, err = ParseUserMask(unparsedmask)
-	t.Logf("Returned error is: %+v", err)
-	if err == nil {
-		t.Fatalf("ParseUserMask should have failed an with error '%s'", err)
+	if testErr != nil {
+		t.Error(testErr)
 	}
-
-	if parsedmask.Type != "" || parsedmask.Nick != "" || parsedmask.Username !=
-		"" || parsedmask.Host != "" {
-		t.Fatalf("ParseUserMark returned a non-empty IrcUserMask after an " +
-			"error.")
-	}
-
-	if err.Error() != "User mask has multiple nick/user seperators." {
-		t.Fatalf("Expected error to be \"User mask has multiple nick/user "+
-			"seperators, got \"%s\"", err)
-	}
+	t.Logf("Returned error is: %+v", pumErr)
 }
 func TestParseUserMaskInvalid2(t *testing.T) {
-	unparsedmask := "te.st!x@client.test"
-	var parsedmask IrcUserMask
-	var err error
+	pumErr, testErr := testBadParseUserMask("te.st!x@client.test",
+		"Nickname contains dots, which isn't permitted.")
 
-	parsedmask, err = ParseUserMask(unparsedmask)
-	t.Logf("Returned error is: %+v", err)
-	if err == nil {
-		t.Fatalf("ParseUserMask should have failed an with error '%s'", err)
+	if testErr != nil {
+		t.Error(testErr)
 	}
-
-	if parsedmask.Type != "" || parsedmask.Nick != "" || parsedmask.Username !=
-		"" || parsedmask.Host != "" {
-		t.Fatalf("ParseUserMark returned a non-empty IrcUserMask after an " +
-			"error.")
-	}
-
-	if err.Error() != "Nickname contains dots, which isn't permitted." {
-		t.Fatalf("Expected error to be \"Nickname contains dots, which isn't "+
-			"permitted.\", got \"%s\"", err)
-	}
+	t.Logf("Returned error is: %+v", pumErr)
 }
 func TestParseUserMaskInvalid3(t *testing.T) {
-	unparsedmask := "test!x@client@client.test"
-	var parsedmask IrcUserMask
-	var err error
+	pumErr, testErr := testBadParseUserMask("test!x@client@client.test",
+		"User mask has multiple host seperators.")
 
-	parsedmask, err = ParseUserMask(unparsedmask)
-	t.Logf("Returned error is: %+v", err)
-	if err == nil {
-		t.Fatalf("ParseUserMask should have failed an with error '%s'", err)
+	if testErr != nil {
+		t.Error(testErr)
 	}
-
-	if parsedmask.Type != "" || parsedmask.Nick != "" || parsedmask.Username !=
-		"" || parsedmask.Host != "" {
-		t.Fatalf("ParseUserMark returned a non-empty IrcUserMask after an " +
-			"error.")
-	}
-
-	if err.Error() != "User mask has multiple host seperators." {
-		t.Fatalf("Expected error to be \"User mask has multiple host "+
-			"seperators.\", got \"%s\"", err)
-	}
+	t.Logf("Returned error is: %+v", pumErr)
 }
 func TestParseUserMaskInvalid4(t *testing.T) {
-	unparsedmask := "test!x.boo@client.test"
-	var parsedmask IrcUserMask
-	var err error
+	pumErr, testErr := testBadParseUserMask("test!x.boo@client.test",
+		"Username contains dots, which isn't permitted.")
 
-	parsedmask, err = ParseUserMask(unparsedmask)
-	t.Logf("Returned error is: %+v", err)
-	if err == nil {
-		t.Fatalf("ParseUserMask should have failed an with error '%s'", err)
+	if testErr != nil {
+		t.Error(testErr)
 	}
-
-	if parsedmask.Type != "" || parsedmask.Nick != "" || parsedmask.Username !=
-		"" || parsedmask.Host != "" {
-		t.Fatalf("ParseUserMark returned a non-empty IrcUserMask after an " +
-			"error.")
-	}
-
-	if err.Error() != "Username contains dots, which isn't permitted." {
-		t.Fatalf("Expected error to be \"Username contains dots, which isn't "+
-			"permitted.\", got \"%s\"", err)
-	}
+	t.Logf("Returned error is: %+v", pumErr)
 }
 func TestParseUserMaskInvalid5(t *testing.T) {
-	unparsedmask := "test!x boo@client.test"
-	var parsedmask IrcUserMask
-	var err error
+	pumErr, testErr := testBadParseUserMask("test!x boo@client.test",
+		"User mask contains reserved characters.")
 
-	parsedmask, err = ParseUserMask(unparsedmask)
-	t.Logf("Returned error is: %+v", err)
-	if err == nil {
-		t.Fatalf("ParseUserMask should have failed an with error '%s'", err)
+	if testErr != nil {
+		t.Error(testErr)
 	}
-
-	if parsedmask.Type != "" || parsedmask.Nick != "" || parsedmask.Username !=
-		"" || parsedmask.Host != "" {
-		t.Fatalf("ParseUserMark returned a non-empty IrcUserMask after an " +
-			"error.")
-	}
-
-	if err.Error() != "User mask contains reserved characters." {
-		t.Fatalf("Expected error to be \"User mask contains reserved "+
-			"characters.\", got \"%s\"", err)
-	}
+	t.Logf("Returned error is: %+v", pumErr)
 }
 
 // ----------------------------------------------------------------------------

--- a/parse_test.go
+++ b/parse_test.go
@@ -235,105 +235,76 @@ func BenchmarkParseRawPing(b *testing.B) {
 // PARSE USER MASK TESTS ------------------------------------------------------
 // ----------------------------------------------------------------------------
 
-func TestParseUserMaskValidUser1(t *testing.T) {
-	unparsedmask := "TestUser!test@user.client.test"
-	var parsedmask IrcUserMask
+func testGoodParseUserMask(testMask, expectedType, expectedNick, expectedUser,
+	expectedHost string) (IrcUserMask, error){
+	// Parse the test mask
+	var parsedMask IrcUserMask
 	var err error
+	parsedMask, err = ParseUserMask(testMask)
 
-	parsedmask, err = ParseUserMask(unparsedmask)
-	t.Logf("Returned structure is: %+v", parsedmask)
+	// Check for unexpected error
 	if err != nil {
-		t.Fatalf("ParseUserMask failed with error '%s'", err)
+		return parsedMask, fmt.Errorf("ParseUserMask failed unexpected with "+
+			"error: %s", err.Error())
 	}
 
-	if parsedmask.Type != "User" {
-		t.Fatalf("Expected Type field to be \"User\", got \"%s\".",
-			parsedmask.Type)
-	} else if parsedmask.Nick != "TestUser" {
-		t.Fatalf("Expected Nick field to be \"TestUser\", got \"%s\".",
-			parsedmask.Nick)
-	} else if parsedmask.Username != "test" {
-		t.Fatalf("Expected Username field to be \"test\", got \"%s\".",
-			parsedmask.Username)
-	} else if parsedmask.Host != "user.client.test" {
-		t.Fatalf("Expected Host field to be \"user.client.test\", got \"%s\".",
-			parsedmask.Host)
+	// Check if we got expected values
+	if parsedMask.Type != expectedType {
+		return parsedMask, fmt.Errorf("ParseUserMask returned unexpected type "+
+			"value of '%s'. We were expecting '%s'.", parsedMask.Type,
+			expectedType)
+	} else if parsedMask.Nick != expectedNick {
+		return parsedMask, fmt.Errorf("ParseUserMask returned unexpected nick "+
+			"value of '%s'. We were expecting '%s'.", parsedMask.Nick,
+			expectedNick)
+	} else if parsedMask.Username != expectedUser {
+		return parsedMask, fmt.Errorf("ParseUserMask returned unexpected user "+
+			"value of '%s'. We were expecting '%s'.", parsedMask.Username,
+			expectedUser)
+	} else if parsedMask.Host != expectedHost {
+		return parsedMask, fmt.Errorf("ParseUserMask returned unexpected host "+
+			"value of '%s'. We were expecting '%s'.", parsedMask.Host,
+			expectedHost)
 	}
+
+	return parsedMask, nil
+}
+
+func TestParseUserMaskValidUser1(t *testing.T) {
+	parsedMask, err := testGoodParseUserMask("TestUser!test@user.client.test",
+		"User", "TestUser", "test", "user.client.test")
+
+	if err != nil {
+		t.Error(err)
+	}
+	t.Logf("Returned structure is: %+v", parsedMask)
 }
 func TestParseUserMaskValidUser2(t *testing.T) {
-	unparsedmask := "TestUser@user.client.test"
-	var parsedmask IrcUserMask
-	var err error
+	parsedMask, err := testGoodParseUserMask("TestUser@user.client.test",
+		"User", "TestUser", "", "user.client.test")
 
-	parsedmask, err = ParseUserMask(unparsedmask)
-	t.Logf("Returned structure is: %+v", parsedmask)
 	if err != nil {
-		t.Fatalf("ParseUserMask failed with error '%s'", err)
+		t.Error(err)
 	}
-
-	if parsedmask.Type != "User" {
-		t.Fatalf("Expected Type field to be \"User\", got \"%s\".",
-			parsedmask.Type)
-	} else if parsedmask.Nick != "TestUser" {
-		t.Fatalf("Expected Nick field to be \"TestUser\", got \"%s\".",
-			parsedmask.Nick)
-	} else if parsedmask.Username != "" {
-		t.Fatalf("Expected Username field to be empty, got \"%s\".",
-			parsedmask.Username)
-	} else if parsedmask.Host != "user.client.test" {
-		t.Fatalf("Expected Host field to be \"user.client.test\", got \"%s\".",
-			parsedmask.Host)
-	}
+	t.Logf("Returned structure is: %+v", parsedMask)
 }
 func TestParseUserMaskValidServer1(t *testing.T) {
-	unparsedmask := "server.test"
-	var parsedmask IrcUserMask
-	var err error
+	parsedMask, err := testGoodParseUserMask("server.test",
+		"Server", "", "", "server.test")
 
-	parsedmask, err = ParseUserMask(unparsedmask)
-	t.Logf("Returned structure is: %+v", parsedmask)
 	if err != nil {
-		t.Fatalf("ParseUserMask failed with error '%s'", err)
+		t.Error(err)
 	}
-
-	if parsedmask.Type != "Server" {
-		t.Fatalf("Expected Type field to be \"Server\", got \"%s\".",
-			parsedmask.Type)
-	} else if parsedmask.Nick != "" {
-		t.Fatalf("Expected Nick field to be empty, got \"%s\".",
-			parsedmask.Nick)
-	} else if parsedmask.Username != "" {
-		t.Fatalf("Expected Username field to be empty, got \"%s\".",
-			parsedmask.Username)
-	} else if parsedmask.Host != "server.test" {
-		t.Fatalf("Expected Host field to be \"server.test\", got \"%s\".",
-			parsedmask.Host)
-	}
+	t.Logf("Returned structure is: %+v", parsedMask)
 }
 func TestParseUserMaskValidAmbigiousMask1(t *testing.T) {
-	unparsedmask := "test"
-	var parsedmask IrcUserMask
-	var err error
+	parsedMask, err := testGoodParseUserMask("test",
+		"Unknown", "test", "", "test")
 
-	parsedmask, err = ParseUserMask(unparsedmask)
-	t.Logf("Returned structure is: %+v", parsedmask)
 	if err != nil {
-		t.Fatalf("ParseUserMask failed with error '%s'", err)
+		t.Error(err)
 	}
-
-	if parsedmask.Type != "Unknown" {
-		t.Fatalf("Expected Type field to be \"Unknown\", got \"%s\".",
-			parsedmask.Type)
-	} else if parsedmask.Nick != "test" {
-		t.Fatalf("Expected Nick field to be \"test\", got \"%s\".",
-			parsedmask.Nick)
-	} else if parsedmask.Username != "" {
-		t.Fatalf("Expected Username field to be empty, got \"%s\".",
-			parsedmask.Username)
-	} else if parsedmask.Host != "test" {
-		t.Fatalf("Expected Host field to be \"test\", got \"%s\".",
-			parsedmask.Host)
-	}
+	t.Logf("Returned structure is: %+v", parsedMask)
 }
 func TestParseUserMaskInvalid1(t *testing.T) {
 	unparsedmask := "test!x!x@client.test"

--- a/parse_test.go
+++ b/parse_test.go
@@ -17,7 +17,7 @@ import (
 // PARSE RAW TESTS ------------------------------------------------------------
 // ----------------------------------------------------------------------------
 
-func testRawIrcCommand(testCmd string, expectedSource IrcUserMask,
+func testGoodParseRaw(testCmd string, expectedSource IrcUserMask,
 	expectedRawType string, expectedRawArguments []string) (IrcCommand,
 	error) {
 	// Fetch parsed command
@@ -68,7 +68,7 @@ func testRawIrcCommand(testCmd string, expectedSource IrcUserMask,
 }
 
 func TestParseRawValid1(t *testing.T) {
-	parsedCmd, err := testRawIrcCommand(":server.test 001 TestUser :Welcome "+
+	parsedCmd, err := testGoodParseRaw(":server.test 001 TestUser :Welcome "+
 		"to the TestNet IRC Network TestUser!test@user.client.test\r\n",
 		IrcUserMask{Type: "Server", Host: "server.test"}, "001",
 		[]string{"TestUser", "Welcome to the TestNet IRC Network " +
@@ -80,7 +80,7 @@ func TestParseRawValid1(t *testing.T) {
 	t.Logf("ParseRaw returned structure: %+v", parsedCmd)
 }
 func TestParseRawValid2(t *testing.T) {
-	parsedCmd, err := testRawIrcCommand(":server.test NOTICE TestUser :This "+
+	parsedCmd, err := testGoodParseRaw(":server.test NOTICE TestUser :This "+
 		"is a notice. Boo!\r\n", IrcUserMask{Type: "Server",
 		Host: "server.test"}, "NOTICE", []string{"TestUser", "This is a " +
 		"notice. Boo!"})
@@ -91,7 +91,7 @@ func TestParseRawValid2(t *testing.T) {
 	t.Logf("ParseRaw returned structure: %+v", parsedCmd)
 }
 func TestParseRawValid3(t *testing.T) {
-	parsedCmd, err := testRawIrcCommand(":OtherUser!foo@second.client.test "+
+	parsedCmd, err := testGoodParseRaw(":OtherUser!foo@second.client.test "+
 		"PRIVMSG TestUser :This is a message. Boo!\r\n",
 		IrcUserMask{Type: "User", Nick: "OtherUser", Username: "foo",
 		Host: "second.client.test"}, "PRIVMSG", []string{"TestUser", "This is "+
@@ -103,7 +103,7 @@ func TestParseRawValid3(t *testing.T) {
 	t.Logf("ParseRaw returned structure: %+v", parsedCmd)
 }
 func TestParseRawValid4(t *testing.T) {
-	parsedCmd, err := testRawIrcCommand(":server.test 005 TestUser CAP1 CAP2 "+
+	parsedCmd, err := testGoodParseRaw(":server.test 005 TestUser CAP1 CAP2 "+
 		"CAP3 CAP4 CAP5 CAP6 CAP7 CAP8 CAP9 CAP10 CAP11 CAP12 CAP13 are "+
 		"supported by this server\r\n", IrcUserMask{Type: "Server",
 		Host: "server.test"}, "005", []string{"TestUser", "CAP1", "CAP2",
@@ -116,7 +116,7 @@ func TestParseRawValid4(t *testing.T) {
 	t.Logf("ParseRaw returned structure: %+v", parsedCmd)
 }
 func TestParseRawValid5(t *testing.T) {
-	parsedCmd, err := testRawIrcCommand("PING :BOOP\r\n",
+	parsedCmd, err := testGoodParseRaw("PING :BOOP\r\n",
 		IrcUserMask{Type: "None"}, "PING", []string{"BOOP"})
 
 	if err != nil {
@@ -125,7 +125,7 @@ func TestParseRawValid5(t *testing.T) {
 	t.Logf("ParseRaw returned structure: %+v", parsedCmd)
 }
 func TestParseRawValid6(t *testing.T) {
-	parsedCmd, err := testRawIrcCommand("TEST BOOP\r\n",
+	parsedCmd, err := testGoodParseRaw("TEST BOOP\r\n",
 		IrcUserMask{Type: "None"}, "TEST", []string{"BOOP"})
 
 	if err != nil {

--- a/parse_test.go
+++ b/parse_test.go
@@ -66,6 +66,26 @@ func testGoodParseRaw(testCmd string, expectedSource IrcUserMask,
 
 	return parsedCmd, nil
 }
+func testBadParseRaw(testCmd string, expectedErrorMsg string) (error, error) {
+	var parsedCmd IrcCommand
+	var err error
+	parsedCmd, err = ParseRaw(testCmd)
+
+	if !reflect.DeepEqual(parsedCmd, IrcCommand{}) {
+		return err, fmt.Errorf("ParseRaw returned a non-empty IrcCommand "+
+			"object, which wasn't expected. The returned object is: %+v",
+			parsedCmd)
+	} else if err == nil {
+		return err, fmt.Errorf("ParseRaw returned an empty error, which "+
+			"wasn't expected.")
+	} else if err.Error() != expectedErrorMsg {
+		return err, fmt.Errorf("ParseRaw returned an unexpected error of '%s'."+
+			" We were expecting an error of '%s'.", err.Error(),
+			expectedErrorMsg)
+	}
+
+	return err, nil
+}
 
 func TestParseRawValid1(t *testing.T) {
 	parsedCmd, err := testGoodParseRaw(":server.test 001 TestUser :Welcome "+
@@ -134,88 +154,40 @@ func TestParseRawValid6(t *testing.T) {
 	t.Logf("ParseRaw returned structure: %+v", parsedCmd)
 }
 func TestParseRawInvalid1(t *testing.T) {
-	unparsedcmd := ":x!x!foo@test PRIVMSG TestUser :Hello\r\n"
-	var parsedcmd IrcCommand
-	var err error
+	prErr, testErr := testBadParseRaw(":x!x!foo@test PRIVMSG TestUser "+
+		":Hello\r\n", "User mask has multiple nick/user seperators.")
 
-	parsedcmd, err = ParseRaw(unparsedcmd)
-	t.Logf("Returned error is: %s", err)
-	if err == nil {
-		t.Fatalf("ParseRaw should have failed with error, but didn't.")
+	if testErr != nil {
+		t.Error(testErr)
 	}
-
-	if parsedcmd.Data != nil || parsedcmd.RawType != "" ||
-		parsedcmd.Type != "" || len(parsedcmd.RawArguments) != 0 {
-		t.Fatalf("ParseRaw returned a non-empty IrcCommand after an error.")
-	}
-
-	if err.Error() != "User mask has multiple nick/user seperators." {
-		t.Fatalf("Expected err to be \"User mask has multiple nick/user "+
-			"seperators.\", it was \"%+v\".", err)
-	}
+	t.Logf("ParseRaw returned error: %+v", prErr)
 }
 func TestParseRawInvalid2(t *testing.T) {
-	unparsedcmd := ":server.test 0a0 TestUser :Hello\r\n"
-	var parsedcmd IrcCommand
-	var err error
+	prErr, testErr := testBadParseRaw(":server.test 0a0 TestUser :Hello\r\n",
+		"Command type is not a valid numeric.")
 
-	parsedcmd, err = ParseRaw(unparsedcmd)
-	t.Logf("Returned error is: %s", err)
-	if err == nil {
-		t.Fatalf("ParseRaw should have failed with error, but didn't.")
+	if testErr != nil {
+		t.Error(testErr)
 	}
-
-	if parsedcmd.Data != nil || parsedcmd.RawType != "" ||
-		parsedcmd.Type != "" || len(parsedcmd.RawArguments) != 0 {
-		t.Fatalf("ParseRaw returned a non-empty IrcCommand after an error.")
-	}
-
-	if err.Error() != "Command type is not a valid numeric." {
-		t.Fatalf("Expected err to be \"Command type is not a valid numeric.\","+
-			" it was \"%+v\".", err)
-	}
+	t.Logf("ParseRaw returned error: %+v", prErr)
 }
 func TestParseRawInvalid3(t *testing.T) {
-	unparsedcmd := ":server.test M30W TestUser :Hello\r\n"
-	var parsedcmd IrcCommand
-	var err error
+	prErr, testErr := testBadParseRaw(":server.test M30W TestUser :Hello\r\n",
+		"Command type contains invalid characters.")
 
-	parsedcmd, err = ParseRaw(unparsedcmd)
-	t.Logf("Returned error is: %s", err)
-	if err == nil {
-		t.Fatalf("ParseRaw should have failed with error, but didn't.")
+	if testErr != nil {
+		t.Error(testErr)
 	}
-
-	if parsedcmd.Data != nil || parsedcmd.RawType != "" ||
-		parsedcmd.Type != "" || len(parsedcmd.RawArguments) != 0 {
-		t.Fatalf("ParseRaw returned a non-empty IrcCommand after an error.")
-	}
-
-	if err.Error() != "Command type contains invalid characters." {
-		t.Fatalf("Expected err to be \"Command type contains invalid "+
-			"characters.\", it was \"%+v\".", err)
-	}
+	t.Logf("ParseRaw returned error: %+v", prErr)
 }
 func TestParseRawInvalid4(t *testing.T) {
-	unparsedcmd := ":server.test 001 TestUser :Hello"
-	var parsedcmd IrcCommand
-	var err error
+	prErr, testErr := testBadParseRaw(":server.test 001 TestUser :Hello",
+		"Command does not end with CRLF.")
 
-	parsedcmd, err = ParseRaw(unparsedcmd)
-	t.Logf("Returned error is: %s", err)
-	if err == nil {
-		t.Fatalf("ParseRaw should have failed with error, but didn't.")
+	if testErr != nil {
+		t.Error(testErr)
 	}
-
-	if parsedcmd.Data != nil || parsedcmd.RawType != "" ||
-		parsedcmd.Type != "" || len(parsedcmd.RawArguments) != 0 {
-		t.Fatalf("ParseRaw returned a non-empty IrcCommand after an error.")
-	}
-
-	if err.Error() != "Command does not end with CRLF." {
-		t.Fatalf("Expected err to be \"Command does not end with CRLF.\", "+
-			"it was \"%+v\".", err)
-	}
+	t.Logf("ParseRaw returned error: %+v", prErr)
 }
 
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
I would like the following changes to be merged into the project:

*  Add generic test function for non-erroring `ParseRaw` tests
*  Add generic test function for erroring `ParseRaw` tests
*  Add generic test function for non-erroring `ParseUserMask` tests
*  Add generic test function for erroring `ParseUserMask` tests
*  Refactor all tests to use the new generic functions

This closes issue #9 
